### PR TITLE
Change /users to /api/users

### DIFF
--- a/app/routes/users.server.routes.js
+++ b/app/routes/users.server.routes.js
@@ -34,17 +34,17 @@ module.exports = function(app) {
     app.get('/signout', users.signout);
         
     // Set up the 'users' base routes 
-    app.route('/users')
+    app.route('/api/users')
         .post(users.create)
         .get(users.list); 
         
     // Set up the 'users' parameterized routes
-     app.route('/users/:userId')
+     app.route('/api/users/:userId')
          .get(users.read)
          .put(users.update)
          .delete(users.delete);
         
-    //app.route('/users/:username')
+    //app.route('/api/users/:username')
     //    .get(users.read)
     //    .put(users.update)
     //     .delete(users.delete);


### PR DESCRIPTION
you could even try changing your express app to automatically use /api as a route prefix and avoid having to do this individually everywhere. As an alternate way (not better), see [this project](https://github.com/pronein/timeToFish/blob/dev/app.js).
